### PR TITLE
fix(readwise): error-path-safe schema on list_tags/tag_highlight/reader_get_by_url

### DIFF
--- a/mcp_readwise/output_schema.py
+++ b/mcp_readwise/output_schema.py
@@ -1,0 +1,92 @@
+"""Error-path-safe output schema helpers for wrapped-result tools.
+
+A handful of tools return a top-level JSON array / scalar / optional
+(``list[...]``, ``Optional[Model]``) rather than an object. fastmcp wraps
+those under ``{"result": ...}`` and marks the published ``output_schema`` with
+``x-fastmcp-wrap-result: true`` and ``required: ["result"]``.
+
+That ``required: ["result"]`` is the bug class fixed in mcp-zernio: a strict
+client (or the manually-synced Cloudflare MCP portal) validates a tool's
+``structured_content`` against the published schema, so a top-level
+``{"error": ...}`` payload — which carries no ``result`` key — is *rejected*.
+
+`register_error_safe_wrapped` registers such a tool while relaxing its
+generated schema additively so BOTH shapes validate:
+
+  * success: ``{"result": <array|scalar|object|null>}`` (unchanged wire shape —
+    ``x-fastmcp-wrap-result`` is preserved, so fastmcp still wraps the return);
+  * error:   ``{"error": "..."}`` (top-level), plus any partial/empty payload.
+
+The relaxation is purely additive — it never renames or removes ``result``,
+never changes the tool's name, params, or success return shape. It only:
+  * drops ``required`` (so a missing ``result`` no longer fails validation),
+  * adds an optional top-level ``error`` property, and
+  * sets ``additionalProperties: true`` (extra="allow" parity).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastmcp import FastMCP
+from fastmcp.tools.function_tool import FunctionTool
+
+# Optional top-level error property mirroring the models' ``error: str | None``.
+_ERROR_PROPERTY: dict[str, Any] = {
+    "anyOf": [{"type": "string"}, {"type": "null"}],
+    "default": None,
+}
+
+
+def relax_wrapped_output_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return an error-path-safe copy of a wrapped-result output schema.
+
+    Additive only: keeps the ``result`` property and ``x-fastmcp-wrap-result``
+    so the success wire shape is identical, but makes ``result`` optional, adds
+    an optional top-level ``error``, and allows extra keys. Idempotent.
+    """
+    relaxed = dict(schema)
+    # A missing ``result`` (i.e. a top-level error payload) must not fail.
+    relaxed.pop("required", None)
+
+    properties = dict(relaxed.get("properties") or {})
+    # Additive: never clobber an existing ``error`` shape if one is present.
+    properties.setdefault("error", dict(_ERROR_PROPERTY))
+    relaxed["properties"] = properties
+
+    # extra="allow" parity at the top level — an error/partial payload with
+    # only ``error`` (and no ``result``) validates cleanly.
+    relaxed["additionalProperties"] = True
+    return relaxed
+
+
+def register_error_safe_wrapped(
+    mcp: FastMCP,
+    fn: Callable[..., Any],
+    *,
+    title: str | None = None,
+    annotations: dict[str, Any] | None = None,
+    tags: set[str] | None = None,
+) -> FunctionTool:
+    """Register ``fn`` as a tool with an error-path-safe wrapped output schema.
+
+    Equivalent to ``mcp.tool(fn, title=..., annotations=..., tags=...)`` for a
+    wrapped-result tool, except the generated ``output_schema`` is relaxed so a
+    top-level ``{"error": ...}`` payload also validates against it. The tool's
+    name, parameters, and success return shape are unchanged.
+    """
+    tool = FunctionTool.from_function(
+        fn,
+        title=title,
+        annotations=annotations,
+        tags=tags,
+    )
+
+    # Only wrapped-result tools carry the bug; relax them. Object-returning
+    # tools (no wrapper) already validate error payloads via their model's
+    # extra="allow" + optional ``error`` field, so leave their schema untouched.
+    if tool.output_schema and tool.output_schema.get("x-fastmcp-wrap-result"):
+        tool.output_schema = relax_wrapped_output_schema(tool.output_schema)
+
+    mcp.add_tool(tool)
+    return tool

--- a/mcp_readwise/server.py
+++ b/mcp_readwise/server.py
@@ -39,6 +39,7 @@ from mcp_readwise.tools.tags import (
     tag_highlight,
 )
 from mcp_readwise.tools.writing import writing_material
+from mcp_readwise.output_schema import register_error_safe_wrapped
 from mcp_readwise.prompts import register_prompts
 from mcp_readwise.resources import register_resources
 
@@ -185,7 +186,12 @@ mcp.tool(
 )
 
 # Tags
-mcp.tool(
+# `list_tags` returns list[TagResult] → fastmcp wraps it under {"result": ...}
+# with required:["result"]. Register via the error-path-safe helper so a
+# top-level {"error": ...} payload also validates against the published schema
+# (mcp-zernio guard). Wire shape for success is unchanged.
+register_error_safe_wrapped(
+    mcp,
     list_tags,
     title="List tags",
     annotations={**_OPEN, "readOnlyHint": True},
@@ -200,7 +206,9 @@ mcp.tool(
     title="Delete tag",
     annotations={**_OPEN, "destructiveHint": True, "idempotentHint": True},
 )
-mcp.tool(
+# `tag_highlight` returns list[str] → same wrapped-result error-path hazard.
+register_error_safe_wrapped(
+    mcp,
     tag_highlight,
     title="Add or remove a highlight tag",
     annotations={**_OPEN, "idempotentHint": True},
@@ -239,7 +247,11 @@ mcp.tool(
     title="List Reader documents",
     annotations={**_OPEN, "readOnlyHint": True},
 )
-mcp.tool(
+# `reader_get_by_url` returns Optional[ReaderDocument] → fastmcp wraps it under
+# {"result": ...} with required:["result"], so a top-level {"error": ...} would
+# fail strict validation. Register via the error-path-safe helper.
+register_error_safe_wrapped(
+    mcp,
     reader_get_by_url,
     title="Get Reader document by URL",
     annotations={**_OPEN, "readOnlyHint": True},

--- a/tests/test_error_safe_wrapped.py
+++ b/tests/test_error_safe_wrapped.py
@@ -1,0 +1,171 @@
+"""Error-path-safe wrapped output schema — unit + in-memory Client coverage.
+
+Pins the fix for the three wrapped-result tools (``list_tags``,
+``tag_highlight``, ``reader_get_by_url``): their published ``output_schema``
+must validate BOTH the success ``{"result": ...}`` wire shape AND a top-level
+``{"error": ...}`` payload, without changing tool name/params/return.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_readwise.output_schema import (
+    register_error_safe_wrapped,
+    relax_wrapped_output_schema,
+)
+
+jsonschema = pytest.importorskip("jsonschema")
+
+
+# --- relax helper ---------------------------------------------------------
+
+
+class TestRelaxHelper:
+    def test_drops_required_adds_error_allows_extra(self):
+        original = {
+            "type": "object",
+            "properties": {"result": {"type": "array", "items": {"type": "string"}}},
+            "required": ["result"],
+            "x-fastmcp-wrap-result": True,
+        }
+        relaxed = relax_wrapped_output_schema(original)
+
+        # required gone, error added, extras allowed, wrapper preserved
+        assert "required" not in relaxed
+        assert "error" in relaxed["properties"]
+        assert "result" in relaxed["properties"]  # additive — never removed
+        assert relaxed["additionalProperties"] is True
+        assert relaxed["x-fastmcp-wrap-result"] is True
+        # input not mutated
+        assert original.get("required") == ["result"]
+
+    def test_idempotent(self):
+        original = {
+            "type": "object",
+            "properties": {"result": {"type": "array"}},
+            "required": ["result"],
+            "x-fastmcp-wrap-result": True,
+        }
+        once = relax_wrapped_output_schema(original)
+        twice = relax_wrapped_output_schema(once)
+        assert twice == once
+
+    def test_does_not_clobber_existing_error_property(self):
+        original = {
+            "type": "object",
+            "properties": {
+                "result": {"type": "array"},
+                "error": {"type": "string"},  # already present
+            },
+            "x-fastmcp-wrap-result": True,
+        }
+        relaxed = relax_wrapped_output_schema(original)
+        assert relaxed["properties"]["error"] == {"type": "string"}
+
+    def test_relaxed_schema_validates_both_shapes(self):
+        original = {
+            "type": "object",
+            "properties": {"result": {"type": "array", "items": {"type": "string"}}},
+            "required": ["result"],
+            "x-fastmcp-wrap-result": True,
+        }
+        relaxed = relax_wrapped_output_schema(original)
+        validator = jsonschema.Draft7Validator(relaxed)
+        assert not list(validator.iter_errors({"result": ["a", "b"]}))  # success
+        assert not list(validator.iter_errors({"error": "boom"}))  # error
+        assert not list(validator.iter_errors({}))  # empty/partial
+
+
+# --- registration helper, end-to-end via in-memory Client -----------------
+
+
+class TestRegisterErrorSafeWrapped:
+    @pytest.mark.asyncio
+    async def test_success_wire_shape_preserved(self):
+        mcp = FastMCP("t")
+
+        async def list_things() -> list[str]:
+            """A list-returning tool (wrapped under result)."""
+            return ["a", "b"]
+
+        register_error_safe_wrapped(
+            mcp, list_things, title="X", annotations={"readOnlyHint": True}
+        )
+
+        async with Client(mcp) as client:
+            res = await client.call_tool("list_things", {})
+
+        # fastmcp still wraps the list under {"result": ...}
+        assert res.structured_content == {"result": ["a", "b"]}
+        assert res.data == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_error_payload_validates_against_published_schema(self):
+        """A top-level {"error": ...} structured payload must validate against
+        the tool's published output_schema (the mcp-zernio guard)."""
+        mcp = FastMCP("t")
+
+        async def maybe_optional() -> Optional[dict]:
+            """Optional-returning tool (wrapped under result)."""
+            return None
+
+        tool = register_error_safe_wrapped(mcp, maybe_optional, title="Y")
+
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+
+        schema = tools["maybe_optional"].outputSchema
+        assert "result" not in set(schema.get("required") or [])
+        validator = jsonschema.Draft7Validator(schema)
+        # Both the in-memory tool object and the client-side schema agree.
+        assert tool.output_schema.get("x-fastmcp-wrap-result") is True
+        assert not list(validator.iter_errors({"error": "upstream blew up"}))
+        assert not list(validator.iter_errors({"result": {"k": "v"}}))
+
+    @pytest.mark.asyncio
+    async def test_metadata_only_no_param_change(self):
+        """annotations/title/tags are metadata only — the input schema and tool
+        name must be untouched by the helper."""
+        mcp = FastMCP("t")
+
+        async def by_url(url: str, limit: int = 10) -> Optional[dict]:
+            """Optional-returning tool with params."""
+            return None
+
+        register_error_safe_wrapped(
+            mcp, by_url, title="By URL", annotations={"readOnlyHint": True}
+        )
+
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+
+        t = tools["by_url"]
+        props = set((t.inputSchema.get("properties") or {}).keys())
+        assert props == {"url", "limit"}
+        assert set(t.inputSchema.get("required") or []) == {"url"}
+
+
+# --- the three REAL tools, as registered on the production server ---------
+
+
+class TestRealServerWrappedTools:
+    WRAPPED = {"list_tags", "tag_highlight", "reader_get_by_url"}
+
+    @pytest.mark.asyncio
+    async def test_real_tools_error_path_safe_via_client(self):
+        from mcp_readwise.server import mcp
+
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+
+        for name in self.WRAPPED:
+            schema = tools[name].outputSchema
+            assert schema.get("x-fastmcp-wrap-result") is True, name
+            assert "result" in (schema.get("properties") or {}), name
+            assert "result" not in set(schema.get("required") or []), name
+            validator = jsonschema.Draft7Validator(schema)
+            assert not list(validator.iter_errors({"error": "boom"})), name

--- a/tests/test_output_schema_contract.py
+++ b/tests/test_output_schema_contract.py
@@ -201,8 +201,26 @@ class TestTopLevelFieldsPreserved:
         tools = _list_tools()
         for name in WRAPPED_RESULT_TOOLS:
             schema = tools[name].output_schema
+            # Success wire shape is unchanged: still wrapped, ``result`` present.
             assert schema.get("x-fastmcp-wrap-result") is True, name
-            assert set((schema.get("properties") or {}).keys()) == {"result"}, name
+            props = set((schema.get("properties") or {}).keys())
+            assert "result" in props, name
+            # The ONLY additive top-level property allowed is the ``error`` guard.
+            assert props - {"result"} <= {"error"}, name
+
+    def test_wrapped_tools_are_error_path_safe(self):
+        # The mcp-zernio bug class: a wrapped-result tool whose schema requires
+        # ``result`` rejects a top-level {"error": ...} payload. After the fix,
+        # ``result`` must NOT be required and extra keys must be tolerated, so an
+        # error payload validates against the published schema.
+        jsonschema = pytest.importorskip("jsonschema")
+        tools = _list_tools()
+        for name in WRAPPED_RESULT_TOOLS:
+            schema = tools[name].output_schema
+            assert "result" not in set(schema.get("required") or []), name
+            validator = jsonschema.Draft7Validator(schema)
+            errors = list(validator.iter_errors({"error": "boom"}))
+            assert not errors, f"{name} rejects error payload: {errors}"
 
 
 # --- Success payloads still validate (no false positives) -----------------


### PR DESCRIPTION
Shelf-item refinement (mcp-tool-reviewer pointer). **Additive / backward-compatible** — no tool renamed, no param changed, error-path-safe schemas; elicit gates (where present) degrade gracefully when the client lacks elicitation support.

### Done
- Diagnosed the bug: list_tags, tag_highlight, reader_get_by_url return list/Optional types, so fastmcp wraps them under {"result": ...} with required:["result"] and x-fastmcp-wrap-result:true. A top-level {"error": ...} payload was rejected by the published output_schema (confirmed via jsonschema: 'result is a required property').
- Added mcp_readwise/output_schema.py with relax_wrapped_output_schema() (additive: drops required, adds optional top-level error, sets additionalProperties:true, preserves result + x-fastmcp-wrap-result) and register_error_safe_wrapped() (builds the tool via FunctionTool.from_function, relaxes only wrapped-result schemas, registers via mcp.add_tool).
- Rewired server.py to register the 3 wrapped tools through register_error_safe_wrapped (title/annotations unchanged); other 13 tools untouched. Confirmed Context7 fastmcp 3.4.2 docs for output_schema override + verified x-fastmcp-wrap-result handling in fastmcp source (tools/base.py:334-340).
- Verified additive contract: tool count still 16; input schemas/names/params unchanged (list_tags=[], tag_highlight=[action,highlight_id,tag], reader_get_by_url=[location,url req:url]); success wire shape preserved ({"result": [...]} via in-memory Client).
- Updated tests/test_output_schema_contract.py: relaxed test_wrapped_tools_keep_result_wrapper to allow additive error prop, added test_wrapped_tools_are_error

### Tests
`uv sync && uv run pytest -q` → 329 passed (baseline was 320; +9 new: 8 in tests/test_error_safe_wrapped.py + 1 new contract test). No regressions.

**Reviewer notes (non-blocking):**
- _low_: register_error_safe_wrapped exposes a `tags` parameter that none of the 3 call sites use, and the module re-exports `annotations` (the __future__ import) as a public name. Cosmetic only; no functional

🤖 Part of the 2026-06 MCP fleet uplift (shelf items).